### PR TITLE
Smoothens log implementation, making it less intrusive

### DIFF
--- a/archiTop/__main__.py
+++ b/archiTop/__main__.py
@@ -4,6 +4,9 @@ import argparse
 from archiTop.scryfall import ScryfallDeckBuilder
 from archiTop.deck_builder import DeckBuilderWrapper
 from archiTop.deck_fetcher import ArchidektFetcher
+from archiTop.config import get_spin_logger
+
+spin_logger = get_spin_logger(__name__)
 
 
 def setup_argparse():
@@ -38,3 +41,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/archiTop/base_classes/deck_builder.py
+++ b/archiTop/base_classes/deck_builder.py
@@ -2,10 +2,9 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from archiTop.config import getLogger, load_config
+from archiTop.config import load_config
 from archiTop.scryfall.data_types import ScryfallCard
 
-logger = getLogger(__name__)
 config = load_config()
 
 

--- a/archiTop/base_classes/deck_fetcher.py
+++ b/archiTop/base_classes/deck_fetcher.py
@@ -5,10 +5,10 @@ from typing import Any, List
 
 import requests
 
-from archiTop.config import getLogger
+from archiTop.config import get_spin_logger
 from archiTop.data_types import RawCard, RawDeck
 
-logger = getLogger(__name__)
+spin_logger = get_spin_logger(__name__)
 
 
 class DeckFetcherError(Exception):
@@ -39,8 +39,10 @@ class DeckFetcher(ABC):
         Returns:
             Deck information in json format
         """
-        logger.debug('Downloading deck <%s>', self.deck_id)
-        return requests.get(self.base_url % self.deck_id)
+        spin_logger.debug('Downloading deck <%s>', self.deck_id, extra={'user_waiting': True})
+        response = requests.get(self.base_url % self.deck_id)
+        spin_logger.debug('Downloaded deck <%s>', self.deck_id, extra={'user_waiting': False})
+        return response
 
     @staticmethod
     def _parse_raw_deck_data(request: requests.Response) -> dict:

--- a/archiTop/config.py
+++ b/archiTop/config.py
@@ -2,6 +2,8 @@ import configparser
 import logging
 from pathlib import Path
 
+from logging_spinner import SpinnerHandler
+
 
 def load_config():
     """Creates config-parser, reading the config and returning the read config
@@ -14,20 +16,15 @@ def load_config():
     return config
 
 
-def setup_logging():
-    logger = logging.getLogger('archiTop')
+def setup_spin_logging():
+    logger = logging.getLogger('archiTop_spin')
     logger.setLevel(load_config()['APP']['LOG_LEVEL'])
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-    # Attach stdout handler to logger (log to console)
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    logger.addHandler(SpinnerHandler())
 
 
-def getLogger(name: str):
-    return logging.getLogger('archiTop.' + name)
+def get_spin_logger(name: str):
+    return logging.getLogger('archiTop_spin.' + name)
 
 
 PACKAGE_ROOT_PATH = Path(__file__).parent
-setup_logging()
+setup_spin_logging()

--- a/archiTop/deck_fetcher/archidekt.py
+++ b/archiTop/deck_fetcher/archidekt.py
@@ -4,10 +4,7 @@ from typing import List, Set
 import requests
 
 from archiTop.base_classes import DeckFetcher, DeckFetcherError
-from archiTop.config import getLogger
 from archiTop.data_types import RawCard
-
-logger = getLogger(__name__)
 
 
 class ArchidektFetcher(DeckFetcher):

--- a/archiTop/scryfall/__init__.py
+++ b/archiTop/scryfall/__init__.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-from archiTop.config import PACKAGE_ROOT_PATH, getLogger, load_config
+from archiTop.config import PACKAGE_ROOT_PATH, get_spin_logger, load_config
 
-logger = getLogger(__name__)
+spin_logger = get_spin_logger(__name__)
 conf = load_config()['SCRYFALL']
 resources_path = Path(PACKAGE_ROOT_PATH, 'resources')
 

--- a/archiTop/scryfall/scryfall_builder.py
+++ b/archiTop/scryfall/scryfall_builder.py
@@ -4,9 +4,9 @@ from typing import List, Tuple
 
 from archiTop.data_types import RawCard, RawDeck
 from archiTop.scryfall.data_types import ScryfallCard, ScryfallDeck
+from archiTop.scryfall.scryfall_fetcher import syncronize_scryfall_data
 from archiTop.scryfall.scryfall_loader import (load_scryfall_name_index,
-                                               load_scryfall_set_name_index,
-                                               syncronize_scryfall_data)
+                                               load_scryfall_set_name_index)
 
 
 class ScryfallDeckBuilder:

--- a/archiTop/scryfall/scryfall_fetcher.py
+++ b/archiTop/scryfall/scryfall_fetcher.py
@@ -3,7 +3,7 @@ import pickle
 
 import requests
 
-from archiTop.scryfall import conf, logger, resources_path
+from archiTop.scryfall import conf, spin_logger, resources_path
 
 
 def _extract_file_name(url: str) -> str:
@@ -28,11 +28,11 @@ def syncronize_scryfall_data():
     current_url = get_bulk_url()
     file_name = _extract_file_name(current_url)
     if not (resources_path / file_name).exists():
-        logger.info('Re-syncing scryfall data...')
+        spin_logger.info('Re-syncing scryfall data', extra={'user_waiting': True})
         # delete outdated scryfall data
         for path in resources_path.glob(conf['BULK_DATA_FILE_PATTERN']):
             path.unlink()
 
         update_scryfall_data(current_url)
 
-        logger.info('Scryfall data is up to date 🎉')
+        spin_logger.info('Scryfall data is up to date 🎉', extra={'user_waiting': False})

--- a/archiTop/scryfall/scryfall_loader.py
+++ b/archiTop/scryfall/scryfall_loader.py
@@ -3,8 +3,7 @@ import pickle
 from functools import lru_cache
 from pathlib import Path
 
-from archiTop.scryfall import conf, logger, resources_path
-from archiTop.scryfall.scryfall_fetcher import syncronize_scryfall_data
+from archiTop.scryfall import conf, spin_logger, resources_path
 
 
 def _get_data_path() -> Path:
@@ -14,8 +13,9 @@ def _get_data_path() -> Path:
 
 @lru_cache
 def _load_scryfall_data(file_path: Path):
-    logger.debug('Loading scryfall data')
+    spin_logger.debug('Loading scryfall data', extra={'user_waiting': True})
     data = pickle.load(file_path.open('rb'))
+    spin_logger.debug('Loaded scryfall data', extra={'user_waiting': False})
     return data
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         long_description_content_type='text/markdown',
         python_requires='>=3.8',
         install_requires=[
-                "requests >= 2.24"
+                "requests >= 2.24",
+                "logging-spinner >= 0.2.2"
         ],
         entry_points={
                 'console_scripts': ['archiTop=archiTop.__main__:main']


### PR DESCRIPTION
Replaces complex logging with simple messages.
Using a spin-logger, longer running processes like fetching the deck and scryfall data are now clearly indicated.
