### PR TITLE
Replace name and set index with uid index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Additional usage information can be acquired via the help command
 
 ### Example
 Let's take one of my decks as example.
-Exporting the deck https://archidekt.com/decks/94674#Maximum_Borkdrive is as simple as copying the deck-id
-In this case `94674`
+Exporting the deck https://archidekt.com/decks/94674#Maximum_Borkdrive is as simple as copying the deck-id `94674`.
 
 By running the tool with the given deck-id:  
 `archiDekt 94674`, archiTop will export the deck as TableTop Simulator compatible file, alongside the thumbnail used for the deck in Archidekt.

--- a/archiTop/__main__.py
+++ b/archiTop/__main__.py
@@ -41,4 +41,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/archiTop/data_types.py
+++ b/archiTop/data_types.py
@@ -8,11 +8,12 @@ class RawCard:
     One class instance can hold multiple quantities of a single card."""
     name: str                   # unique card name
     quantity: int               # quantity for card
+    uid: str                    # unique card identifier
     editioncode: str = None     # edition code for card
     commander: bool = False     # flag whether card is commander
 
     def __repr__(self):
-        return f'RawCard({self.quantity: <3}x {self.name} - {self.editioncode})'
+        return f'RawCard({self.quantity: <3}x {self.name} - {self.editioncode} - {self.uid})'
 
 
 @dataclass

--- a/archiTop/deck_fetcher/archidekt.py
+++ b/archiTop/deck_fetcher/archidekt.py
@@ -23,12 +23,13 @@ class ArchidektFetcher(DeckFetcher):
         card_data = card['card']
 
         name = card_data['oracleCard']['name']
+        uid = card_data['uid']
         quantity = card['quantity']
 
         edition_code = card_data['edition']['editioncode']
         commander = card['category'] == 'Commander' or 'Commander' in card.get('categories', ())
 
-        return RawCard(name, quantity, edition_code, commander)
+        return RawCard(name, quantity, uid, edition_code, commander)
 
     @staticmethod
     def _handle_raw_deck_request(response: requests.Response):

--- a/archiTop/scryfall/__init__.py
+++ b/archiTop/scryfall/__init__.py
@@ -8,4 +8,4 @@ resources_path = Path(PACKAGE_ROOT_PATH, 'resources')
 
 from .scryfall_builder import ScryfallDeckBuilder
 from .scryfall_fetcher import syncronize_scryfall_data, syncronize_scryfall_data
-from .scryfall_loader import load_scryfall_set_name_index
+from .scryfall_loader import load_scryfall_id_index

--- a/archiTop/scryfall/data_types.py
+++ b/archiTop/scryfall/data_types.py
@@ -41,7 +41,6 @@ class ScryfallCard:
                                                    resolve_tokens=False,
                                                    card_side=1)}
 
-
         else:
             raise Exception('Unknown card-type encountered')
 

--- a/archiTop/scryfall/scryfall_builder.py
+++ b/archiTop/scryfall/scryfall_builder.py
@@ -5,8 +5,7 @@ from typing import List, Tuple
 from archiTop.data_types import RawCard, RawDeck
 from archiTop.scryfall.data_types import ScryfallCard, ScryfallDeck
 from archiTop.scryfall.scryfall_fetcher import syncronize_scryfall_data
-from archiTop.scryfall.scryfall_loader import (load_scryfall_name_index,
-                                               load_scryfall_set_name_index)
+from archiTop.scryfall.scryfall_loader import load_scryfall_id_index
 
 
 class ScryfallDeckBuilder:
@@ -15,8 +14,7 @@ class ScryfallDeckBuilder:
         syncronize_scryfall_data()
 
         # load index to search by name and scryfall id
-        self.name_index = load_scryfall_name_index()
-        self.set_name_index = load_scryfall_set_name_index()
+        self.scryfall_id_index = load_scryfall_id_index()
         self.raw_deck = raw_deck
 
     def construct_deck(self) -> ScryfallDeck:
@@ -31,15 +29,12 @@ class ScryfallDeckBuilder:
         scryfall_cards = [self._create_scryfall_card(card) for card in mainboard]
 
         # extract related cards for scryfall cards (token, etc.)
-        related_cards = reduce(lambda set1, set2: set1 | set2,
+        related_cards = reduce(lambda set_1, set_2: set_1 | set_2,
                                [card.related_cards for card in scryfall_cards])
         return scryfall_cards, related_cards
 
     def _create_scryfall_card(self, card: RawCard) -> ScryfallCard:
-        if card.editioncode is not None:
-            scryfall_data = self.set_name_index[card.editioncode][card.name]
-        else:
-            scryfall_data = self.name_index[card.name]
+        scryfall_data = self.scryfall_id_index[card.uid]
         return ScryfallCard(scryfall_data,
                             quantity=card.quantity,
                             commander=card.commander)

--- a/archiTop/scryfall/scryfall_loader.py
+++ b/archiTop/scryfall/scryfall_loader.py
@@ -2,6 +2,7 @@
 import pickle
 from functools import lru_cache
 from pathlib import Path
+from typing import Dict
 
 from archiTop.scryfall import conf, spin_logger, resources_path
 
@@ -20,37 +21,11 @@ def _load_scryfall_data(file_path: Path):
 
 
 @lru_cache
-def _load_scryfall_name_index(file_path: Path):
-    data = _load_scryfall_data(file_path)
-    return {entry['name']: entry for entry in data}
-
-
-@lru_cache
-def _load_scryfall_id_index(file_path: Path):
+def _load_scryfall_id_index(file_path: Path) -> Dict[str, Dict]:
     data = _load_scryfall_data(file_path)
     return {entry['id']: entry for entry in data}
 
 
-@lru_cache
-def _load_scryfall_set_name_index(file_path: Path):
-    data = _load_scryfall_data(file_path)
-    index = {}
-    for entry in data:
-        index[entry['set']] = index.get(entry['set'], {})
-        index[entry['set']][entry['name']] = entry
-    return index
-
-
-def load_scryfall_name_index():
-    file_path = _get_data_path()
-    return _load_scryfall_name_index(file_path)
-
-
-def load_scryfall_id_index():
+def load_scryfall_id_index() -> Dict[str, Dict]:
     file_path = _get_data_path()
     return _load_scryfall_id_index(file_path)
-
-
-def load_scryfall_set_name_index():
-    file_path = _get_data_path()
-    return _load_scryfall_set_name_index(file_path)


### PR DESCRIPTION
Tool was previously using a set and name index to match the archidekt cards with their scryfall data. This led to potentially matching a card to a different art-style version of the same set + name.

PR addresses the issue by replacing the set + name index with a Scryfall id index